### PR TITLE
Add fs/local.NewVolume() and backoff/time.SecondsRangeBackoff()

### DIFF
--- a/backoff/time/time.go
+++ b/backoff/time/time.go
@@ -29,6 +29,14 @@ package time
 import (
 	"context"
 	"time"
+
+	"github.com/wtsi-ssg/wr/backoff"
+)
+
+const (
+	secondsRangeMin    = 250 * time.Millisecond
+	secondsRangeMax    = 3 * time.Second
+	secondsRangeFactor = 1.5
 )
 
 // Sleeper represents an implementation of backoff.Sleeper. It does an actual
@@ -43,5 +51,17 @@ func (s *Sleeper) Sleep(ctx context.Context, d time.Duration) {
 		return
 	case <-ctx.Done():
 		return
+	}
+}
+
+// SecondsRangeBackoff returns a ready-to-use, generally useful backoff.Backoff
+// that uses our Sleeper to start sleeping in the sub-second range and soon
+// backs off to sleeping for a few seconds.
+func SecondsRangeBackoff() *backoff.Backoff {
+	return &backoff.Backoff{
+		Min:     secondsRangeMin,
+		Max:     secondsRangeMax,
+		Factor:  secondsRangeFactor,
+		Sleeper: &Sleeper{},
 	}
 }

--- a/backoff/time/time_test.go
+++ b/backoff/time/time_test.go
@@ -60,4 +60,12 @@ func TestSleeper(t *testing.T) {
 		sleeper.Sleep(ctx, delay)
 		So(time.Now(), ShouldHappenBetween, tn.Add(cancelAfter), tn.Add(500*time.Millisecond))
 	})
+
+	Convey("SecondsRangeBackoff returns a generally useful Backoff in the seconds range", t, func() {
+		b := SecondsRangeBackoff()
+		So(b.Min, ShouldEqual, secondsRangeMin)
+		So(b.Max, ShouldEqual, secondsRangeMax)
+		So(b.Factor, ShouldEqual, secondsRangeFactor)
+		So(b.Sleeper, ShouldHaveSameTypeAs, &Sleeper{})
+	})
 }

--- a/fs/volume_test.go
+++ b/fs/volume_test.go
@@ -34,22 +34,12 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/wtsi-ssg/wr/backoff"
 	bm "github.com/wtsi-ssg/wr/backoff/mock"
-	"github.com/wtsi-ssg/wr/fs/local"
 	"github.com/wtsi-ssg/wr/fs/mock"
 )
 
 func TestVolume(t *testing.T) {
 	ctx := context.Background()
 	path := os.TempDir()
-
-	Convey("You can get the size of a Volume", t, func() {
-		volume := &Volume{Dir: path, UsageCalculator: &local.VolumeUsageCalculator{}}
-		So(volume.Size(ctx), ShouldBeGreaterThanOrEqualTo, 0)
-
-		Convey("And ask if there's no space left", func() {
-			So(volume.NoSpaceLeft(ctx), ShouldBeFalse)
-		})
-	})
 
 	Convey("Calling Size() multiple times calculates the size multiple times", t, func() {
 		expectedSize := 1


### PR DESCRIPTION
When a typical client needs to use the fs and backoff packages, the usage is quite complex and involves importing multiple packages.

Convenience methods fs/local.NewVolume() and backoff/time.SecondsRangeBackoff() are added here to simplify client usage and only require 1 import.