### PR TITLE
New port package.

### DIFF
--- a/internal/tests_test.go
+++ b/internal/tests_test.go
@@ -40,7 +40,7 @@ func TestTestFuncs(t *testing.T) {
 		basename := "foo"
 		path := FilePathInTempDir(t, basename)
 		fmt.Printf("got path %s\n", path)
-		So(path, ShouldStartWith, "/tmp")
+		So(path, ShouldStartWith, os.TempDir())
 		So(path, ShouldEndWith, basename)
 		_, err := os.Open(filepath.Dir(path))
 		So(err, ShouldBeNil)

--- a/network/port/port.go
+++ b/network/port/port.go
@@ -1,0 +1,145 @@
+package port
+
+import (
+	"fmt"
+	"net"
+)
+
+const maxPort = 65535
+const maxTries = maxPort - 10000
+
+// Checker is used to check for available ports on a host.
+type Checker struct {
+	addr      *net.TCPAddr
+	listeners []*net.TCPListener
+	ports     map[int]bool
+}
+
+// NewChecker returns a Checker that can check ports on the given host.
+func NewChecker(host string) (*Checker, error) {
+	addr, err := net.ResolveTCPAddr("tcp", host+":0")
+	if err != nil {
+		return nil, err
+	}
+
+	return &Checker{
+		addr:  addr,
+		ports: make(map[int]bool),
+	}, nil
+}
+
+// AvailableRange asks the operating system for ports until it is given a
+// contiguous range of ports size long. It returns the first and last of those
+// port numbers, having released all the ports it took, so they are ready for
+// you to use.
+//
+// NB: there is the potential for a race condition here, where once released,
+// another process gets one of the ports before you use it, so start listening
+// on all the returned ports as soon as possible after calling this.
+func (c *Checker) AvailableRange(size int) (int, int, error) {
+	var err error
+	defer func() {
+		errr := c.release()
+		if errr != nil {
+			if err == nil {
+				err = errr
+			} else {
+				err = fmt.Errorf("%w; %s", err, errr.Error())
+			}
+		}
+	}()
+
+	for i := 0; i < maxTries; i++ {
+		port, erra := c.availablePort()
+		if erra != nil {
+			err = fmt.Errorf("%w; %s", err, erra.Error())
+			continue
+		}
+
+		if set, has := c.checkRange(port, size); has {
+			min, max := firstAndLast(set)
+			return min, max, err
+		}
+	}
+
+	return 0, 0, err
+}
+
+func (c *Checker) availablePort() (int, error) {
+	l, err := net.ListenTCP("tcp", c.addr)
+	if err != nil {
+		return 0, err
+	}
+	c.listeners = append(c.listeners, l)
+	port := l.Addr().(*net.TCPAddr).Port
+	c.ports[port] = true
+
+	return port, nil
+}
+
+func (c *Checker) checkRange(start, size int) ([]int, bool) {
+	if len(c.ports) < size {
+		return nil, false
+	}
+
+	after := c.portsAfter(start)
+	if len(after)+1 >= size {
+		return append([]int{start}, after[0:size-1]...), true
+	}
+
+	before := c.portsBefore(start)
+	if len(before)+1 >= size {
+		return append(before[len(before)-size+1:], start), true
+	}
+
+	if len(before)+len(after)+1 >= size {
+		combined := append(before, append([]int{start}, after...)...)
+		return combined[0:size], true
+	}
+
+	return nil, false
+}
+
+func (c *Checker) portsAfter(start int) []int {
+	var ports []int
+	for i := start + 1; i <= maxPort; i++ {
+		if c.ports[i] {
+			ports = append(ports, i)
+		} else {
+			return ports
+		}
+	}
+	return ports
+}
+
+func (c *Checker) portsBefore(start int) []int {
+	var ports []int
+	for i := start - 1; i >= 1; i-- {
+		if c.ports[i] {
+			ports = append([]int{i}, ports...)
+		} else {
+			return ports
+		}
+	}
+	return ports
+}
+
+func (c *Checker) release() error {
+	var err error
+
+	for _, l := range c.listeners {
+		errl := l.Close()
+		if errl != nil {
+			err = fmt.Errorf("%w; %s", err, errl.Error())
+		}
+	}
+
+	c.listeners = nil
+	c.ports = make(map[int]bool)
+
+	return err
+}
+
+func firstAndLast(s []int) (min, max int) {
+	return s[0], s[len(s)-1]
+}

--- a/network/port/port.go
+++ b/network/port/port.go
@@ -1,3 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
 package port
 
 import (

--- a/network/port/port_test.go
+++ b/network/port/port_test.go
@@ -19,7 +19,7 @@ func TestPort(t *testing.T) {
 			So(len(checker.ports), ShouldEqual, 1)
 			So(checker.ports[port], ShouldBeTrue)
 
-			err = checker.release()
+			err = checker.release(err)
 			So(err, ShouldBeNil)
 		})
 

--- a/network/port/port_test.go
+++ b/network/port/port_test.go
@@ -1,0 +1,134 @@
+package port
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestPort(t *testing.T) {
+	Convey("Given a Checker", t, func() {
+		checker, err := NewChecker("localhost")
+		So(err, ShouldBeNil)
+		So(checker, ShouldNotBeNil)
+
+		Convey("You can get an available port number", func() {
+			port, err := checker.availablePort()
+			So(err, ShouldBeNil)
+			So(port, ShouldBeBetweenOrEqual, 1, maxPort)
+			So(len(checker.ports), ShouldEqual, 1)
+			So(checker.ports[port], ShouldBeTrue)
+
+			err = checker.release()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("portsAfter works", func() {
+			after := checker.portsAfter(10)
+			So(len(after), ShouldEqual, 0)
+
+			checker.ports[9] = true
+			checker.ports[12] = true
+			checker.ports[13] = true
+			checker.ports[15] = true
+
+			after = checker.portsAfter(10)
+			So(len(after), ShouldEqual, 0)
+
+			checker.ports[11] = true
+			after = checker.portsAfter(10)
+			So(len(after), ShouldEqual, 3)
+			So(after, ShouldResemble, []int{11, 12, 13})
+		})
+
+		Convey("portsBefore works", func() {
+			after := checker.portsBefore(10)
+			So(len(after), ShouldEqual, 0)
+
+			checker.ports[11] = true
+			checker.ports[8] = true
+			checker.ports[7] = true
+			checker.ports[5] = true
+
+			after = checker.portsBefore(10)
+			So(len(after), ShouldEqual, 0)
+
+			checker.ports[9] = true
+			after = checker.portsBefore(10)
+			So(len(after), ShouldEqual, 3)
+			So(after, ShouldResemble, []int{7, 8, 9})
+		})
+
+		Convey("checkRange returns nothing with no available ports", func() {
+			set, has := checker.checkRange(10, 4)
+			So(has, ShouldBeFalse)
+			So(len(set), ShouldEqual, 0)
+
+			Convey("but returns ports above starting point", func() {
+				checker.ports[9] = true
+				checker.ports[11] = true
+				checker.ports[12] = true
+				checker.ports[13] = true
+				checker.ports[14] = true
+
+				set, has := checker.checkRange(10, 4)
+				So(has, ShouldBeTrue)
+				So(len(set), ShouldEqual, 4)
+				So(set, ShouldResemble, []int{10, 11, 12, 13})
+			})
+
+			Convey("but returns ports below starting point", func() {
+				checker.ports[11] = true
+				checker.ports[9] = true
+				checker.ports[8] = true
+				checker.ports[7] = true
+				checker.ports[6] = true
+
+				set, has := checker.checkRange(10, 4)
+				So(has, ShouldBeTrue)
+				So(len(set), ShouldEqual, 4)
+				So(set, ShouldResemble, []int{7, 8, 9, 10})
+			})
+
+			Convey("but returns ports below and above starting point", func() {
+				checker.ports[8] = true
+				checker.ports[9] = true
+				checker.ports[11] = true
+				checker.ports[12] = true
+
+				set, has := checker.checkRange(10, 4)
+				So(has, ShouldBeTrue)
+				So(len(set), ShouldEqual, 4)
+				So(set, ShouldResemble, []int{8, 9, 10, 11})
+			})
+
+			Convey("and returns nothing with non-contiguous available ports", func() {
+				checker.ports[7] = true
+				checker.ports[8] = true
+				checker.ports[12] = true
+				checker.ports[13] = true
+
+				set, has := checker.checkRange(10, 4)
+				So(has, ShouldBeFalse)
+				So(len(set), ShouldEqual, 0)
+			})
+		})
+
+		Convey("You can get a range of available ports multiple times in a row", func() {
+			min, max, err := checker.AvailableRange(2)
+			So(err, ShouldBeNil)
+			So(min, ShouldBeBetweenOrEqual, 1, maxPort)
+			So(max, ShouldEqual, min+1)
+
+			min, max, err = checker.AvailableRange(67)
+			So(err, ShouldBeNil)
+			So(min, ShouldBeBetweenOrEqual, 1, maxPort)
+			So(max, ShouldEqual, min+66)
+
+			min, max, err = checker.AvailableRange(67)
+			So(err, ShouldBeNil)
+			So(min, ShouldBeBetweenOrEqual, 1, maxPort)
+			So(max, ShouldEqual, min+66)
+		})
+	})
+}

--- a/network/port/port_test.go
+++ b/network/port/port_test.go
@@ -1,3 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
 package port
 
 import (


### PR DESCRIPTION
This will be used initially in the old code base to implement VertebrateResequencing/wr#398 , where we want to get a contiguous range of available ports to suggest to the user.